### PR TITLE
Colon is not allowed in runtime environment name

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -3,7 +3,7 @@ tls_verify: false
 requirements_format: pipenv
 
 runtime_environments:
-  - name: 'ubi:8'
+  - name: 'ubi-8'
     operating_system:
       name: ubi
       version: "8"


### PR DESCRIPTION
## Related Issues and Dependencies

See docs: https://github.com/thoth-station/thamos/
